### PR TITLE
Remove PackagesFactory.getDeliveryTimeOptions().

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "install-pre-commit": "ln -s ../../bin/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit"
   },
   "url": "https://citypantry.com/",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "copyright": "2015",
   "dependencies": {
   },

--- a/src/factories/PackagesFactory.js
+++ b/src/factories/PackagesFactory.js
@@ -63,26 +63,6 @@ angular.module('cpLib').factory('PackagesFactory', function(ApiService,
             ];
         },
 
-        getDeliveryTimeOptions: () => {
-            var minutes = 0;
-
-            const options = [];
-
-            while (minutes < 60 * 24) {
-                let hour = ('0' + Math.floor(minutes / 60)).slice(-2);
-                let minute = ('0' + minutes % 60).slice(-2);
-
-                options.push({
-                    label: hour + ':' + minute,
-                    value: parseInt(hour + minute, 10)
-                });
-
-                minutes += 30;
-            }
-
-            return options;
-        },
-
         getNoticeOptions: () => {
             return [
                 { label: '1 hour',   value: 1 },
@@ -150,6 +130,15 @@ angular.module('cpLib').factory('PackagesFactory', function(ApiService,
             return [1, 2, 3].map(value => ({ value, label: getPackagingTypeTextFilter(value) }));
         },
 
+        /**
+         * The 'start' and 'end' parameters should be the time in 24-hour clock as an integer,
+         * e.g. 730 for 07:30, or 2330 for 23:30.
+         *
+         * @param  {Number} start
+         * @param  {Number} end
+         * @param  {Number} interval
+         * @return {Array}
+         */
         getPackageDeliveryTimeOptions: (start, end, interval = 15) => {
             let startMinutes = (Math.floor(start / 100) * 60) + (start % 100);
             let endMinutes = (Math.floor(end / 100) * 60) + (end % 100);

--- a/tests/unit/factories/PackagesFactory.spec.js
+++ b/tests/unit/factories/PackagesFactory.spec.js
@@ -42,4 +42,31 @@ describe('PackagesFactory', function () {
                 .toContain('eventTypeIds[]=aaa&eventTypeIds[]=bbb');
         });
     });
+
+    describe('getPackageDeliveryTimeOptions', function() {
+        it('should return an array of objects, each with a label and a value', function() {
+            var result = PackagesFactory.getPackageDeliveryTimeOptions(700, 1400);
+            expect(result[0]).toEqual({label: '07:00', value: 700});
+        });
+
+        it('should space each time the specified interval apart', function() {
+            var result = PackagesFactory.getPackageDeliveryTimeOptions(700, 1400, 25);
+            expect(result[0].value).toBe(700);
+            expect(result[1].value).toBe(725);
+            expect(result[2].value).toBe(750);
+            expect(result[3].value).toBe(815);
+            expect(result[4].value).toBe(840);
+            expect(result[5].value).toBe(905);
+        });
+
+        it('should format the start of the day as 00:00', function() {
+            var result = PackagesFactory.getPackageDeliveryTimeOptions(0, 30);
+            expect(result[0]).toEqual({label: '00:00', value: 0});
+        });
+
+        it('should format the end of the day as 24:00', function() {
+            var result = PackagesFactory.getPackageDeliveryTimeOptions(2300, 2400, 15);
+            expect(result[4]).toEqual({label: '24:00', value: 2400});
+        });
+    });
 });


### PR DESCRIPTION
This method was basically duplication of
`PackagesFactory.getPackageDeliveryTimeOptions()`.

Also added tests for `getPackageDeliveryTimeOptions()`.

Will update frontend to use `getPackageDeliveryTimeOptions`

![image](https://cloud.githubusercontent.com/assets/398210/7181027/1ec7eb38-e43f-11e4-86fd-dec60d9551a3.png)
