### PR TITLE
Fix bugs in slugify filter.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "install-pre-commit": "ln -s ../../bin/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit"
   },
   "url": "https://citypantry.com/",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "copyright": "2015",
   "dependencies": {
   },

--- a/src/filters/slugifyFilter.js
+++ b/src/filters/slugifyFilter.js
@@ -1,3 +1,8 @@
 angular.module('cpLib').filter('slugify', function() {
-    return text => String(text).replace(/ +/g, '-').toLowerCase();
+    return text => String(text)
+        .replace(/ +/g, '-')
+        .replace(/\//g, '-')
+        .replace(/-{2,}/g, '-')
+        .replace(/(.)[\.-]*$/, '$1')
+        .toLowerCase();
 });

--- a/tests/unit/filters/slugifyFilter.spec.js
+++ b/tests/unit/filters/slugifyFilter.spec.js
@@ -1,0 +1,24 @@
+describe('slugify filter', function() {
+    'use strict';
+
+    beforeEach(function () {
+        module('cpLib');
+    });
+
+    it('should replace slash characters so they do not interfere with our routing definitions', inject(function(slugifyFilter) {
+        expect(slugifyFilter('a/b')).toEqual('a-b');
+    }));
+
+    it('should replace space characters so they do not mess up the address bar', inject(function(slugifyFilter) {
+        expect(slugifyFilter('a b')).toEqual('a-b');
+    }));
+
+    it('should not remove an entire string', inject(function(slugifyFilter) {
+        expect(slugifyFilter('/')).toEqual('-');
+    }));
+
+    it('should slugify real package names to an appropriate slug', inject(function(slugifyFilter) {
+        expect(slugifyFilter('The Fat Controller Vs 3:10 to Yuma (w/ FRIES) - 12Hr. Beef Rib & 10Hr. Pulled Pork.'))
+            .toEqual('the-fat-controller-vs-3:10-to-yuma-(w-fries)-12hr.-beef-rib-&-10hr.-pulled-pork');
+    }));
+});


### PR DESCRIPTION
The filter was causing broken URLs like this: https://order.citypantry.com/package/374-the-fat-controller-vs-310-to-yuma-():/w-fries---12hr.-beef-rib-&-10hr.-pulled-pork

![image](https://cloud.githubusercontent.com/assets/398210/7349793/8032304c-ecf3-11e4-82cc-3d8e82d49d65.png)
