### PR TITLE
Remove old and now redundant order status, NOT_PLACED.

### DIFF
--- a/src/factories/OrdersFactory.js
+++ b/src/factories/OrdersFactory.js
@@ -34,8 +34,7 @@ angular.module('cpLib').factory('OrdersFactory', function(ApiService) {
 
                     const now = new Date();
 
-                    return orders.filter((order) => order.statusText !== 'not_placed')
-                        .filter((order) => getDateObject(order.requestedDeliveryDate) >= now)
+                    return orders.filter((order) => getDateObject(order.requestedDeliveryDate) >= now)
                         .sort((a, b) => getDateObject(a.requestedDeliveryDate) - getDateObject(b.requestedDeliveryDate))
                         .shift();
                 });

--- a/src/filters/getOrderStatusTextFilter.js
+++ b/src/filters/getOrderStatusTextFilter.js
@@ -1,8 +1,6 @@
 angular.module('cpLib').filter('getOrderStatusText', function() {
     return function(status) {
         switch (status) {
-            case 'not_placed':
-                return 'Not placed';
             case 'pending_vendor_approval':
                 return 'Pending vendor approval';
             case 'accepted':

--- a/tests/unit/factories/OrdersFactory.spec.js
+++ b/tests/unit/factories/OrdersFactory.spec.js
@@ -17,7 +17,7 @@ describe('OrdersFactory', function () {
         it('should resolve to the nearest placed order from an array of orders of varying dates and statuses', function() {
             $httpBackend.expectGET('http://api-base/orders/by-current-customer').respond({
                 orders: [
-                    {id: 1, statusText: 'not_placed', requestedDeliveryDate: '2020-02-01T12:00:00Z'},
+                    {id: 1, statusText: 'pending_vendor_approval', requestedDeliveryDate: '2020-02-04T12:00:00Z'},
                     {id: 2, statusText: 'pending_vendor_approval', requestedDeliveryDate: '2020-02-03T12:00:00Z'},
                     {id: 3, statusText: 'accepted', requestedDeliveryDate: '2020-02-02T12:00:00Z'},
                 ],


### PR DESCRIPTION
Related to (but not dependant on): https://github.com/CityPantry/citypantry-3-api/pull/375

![image](https://cloud.githubusercontent.com/assets/398210/7848645/95465b72-04c5-11e5-961f-5fc918e5b37e.png)
